### PR TITLE
Rename recipe.action_name to recipe.action in Normandy API

### DIFF
--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -108,8 +108,8 @@ exports.RecipeRunner = {
 
     sandbox.setTimeout = Cu.cloneInto(setTimeout, sandbox, {cloneFunctions: true});
 
-    Log.debug('Loading action', recipe.action_name);
-    let action = yield NormandyApi.fetchAction(recipe.action_name);
+    Log.debug('Loading action', recipe.action);
+    let action = yield NormandyApi.fetchAction(recipe.action);
 
     Log.debug('Loading implementation from', action.implementation_url);
     let response = yield Http.get({url: action.implementation_url});


### PR DESCRIPTION
This is to deal with the change in mozilla/normandy#167.

r? @casebenton 
