### PR TITLE
Add stable sampling to jexl filtering

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,3 +13,5 @@ globals:
   require: false
   exports: true
   uneval: false
+  crypto: true
+  TextEncoder: true

--- a/.jpmignore
+++ b/.jpmignore
@@ -2,9 +2,7 @@
 .*
 !/data/**/*
 !/lib/**/*
-!/node_modules/inherits/*
 !/node_modules/jexl/**/*
-!/node_modules/sha.js/*
 !/index.js
 !/LICENSE
 !/README.md

--- a/.jpmignore
+++ b/.jpmignore
@@ -2,7 +2,9 @@
 .*
 !/data/**/*
 !/lib/**/*
+!/node_modules/inherits/*
 !/node_modules/jexl/**/*
+!/node_modules/sha.js/*
 !/index.js
 !/LICENSE
 !/README.md

--- a/lib/EnvExpressions.js
+++ b/lib/EnvExpressions.js
@@ -2,6 +2,7 @@ const {Cu} = require('chrome');
 Cu.import('resource://gre/modules/TelemetryController.jsm'); /* globals TelemetryController: false */
 
 const {Jexl} = require('jexl');
+const {stableSample} = require('./stableSample.js');
 
 function getEnv() {
   return {
@@ -12,6 +13,7 @@ function getEnv() {
 const jexl = new Jexl();
 jexl.addTransforms({
   date: dateString => new Date(dateString),
+  stableSample: stableSample,
 });
 
 exports.EnvExpressions = {

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -91,6 +91,11 @@ exports.RecipeRunner = {
       .then(result => {
         Log.debug(`Filter for "${recipe.name}": "${filter}" -> ${result}`);
         return !!result;
+      })
+      .catch(error => {
+        Log.debug(`Error checking filter for "${recipe.name}"`);
+        Log.debug(`Filter: "${filter}"`);
+        Log.debug(`Error: "${error}"`);
       });
     }
   },

--- a/lib/stableSample.js
+++ b/lib/stableSample.js
@@ -1,0 +1,47 @@
+const Sha256 = require('sha.js/sha256');
+
+/**
+ * Map from the range [0, 1] to [0, max(sha256)].
+ * @param  {number} frac A float from 0.0 to 1.0.
+ * @return {string} A string in the sha256 hash space. Will be zero padded to 64
+ *   characters.
+ */
+function fractionToKey(frac) {
+    // SHA 256 hashes are 64-digit hexadecimal numbers. The largest possible SHA
+    // 256 hash is 2^256 - 1.
+
+  if (frac < 0 || frac > 1) {
+    throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
+  }
+
+  const mult = 2 * 256 - 1;
+  const inDecimal = Math.floor(frac * mult);
+  let hexDigits = inDecimal.toString(16);
+  if (hexDigits.length < 64) {
+        // Left pad with zeroes
+        // If N zeroes are needed, generate an array of nulls N+1 elements long,
+        // and inserts zeroes between each null.
+    hexDigits = Array(64 - hexDigits.length + 1).join('0') + hexDigits;
+  }
+
+    // Saturate at 2**256 - 1
+  if (hexDigits.length > 64) {
+    hexDigits = Array(65).join('f');
+  }
+
+  return hexDigits;
+}
+
+exports.stableSample = function(input, rate) {
+  const hasher = new Sha256();
+  hasher.update(JSON.stringify(input));
+
+  const samplePoint = fractionToKey(rate);
+  const inputHash = hasher.digest('hex');
+
+  if (samplePoint.length !== 64 || inputHash.length !== 64) {
+    throw new Error('Unexpected hash length');
+  }
+
+  return inputHash < samplePoint;
+};

--- a/lib/stableSample.js
+++ b/lib/stableSample.js
@@ -35,7 +35,7 @@ function fractionToKey(frac) {
   return hexDigits;
 }
 
-function hex(buffer) {
+function bufferToHex(buffer) {
   let hexCodes = [];
   let view = new DataView(buffer);
   for (let i = 0; i < view.byteLength; i += 4) {
@@ -58,7 +58,7 @@ exports.stableSample = function(input, rate) {
 
   return hasher.digest('SHA-256', new TextEncoder('utf-8').encode(JSON.stringify(input)))
     .then(hash => {
-      const inputHash = hex(hash);
+      const inputHash = bufferToHex(hash);
       const samplePoint = fractionToKey(rate);
 
       Log.info(`SamplePoint: ${samplePoint} -> length: ${samplePoint.length}`);

--- a/lib/stableSample.js
+++ b/lib/stableSample.js
@@ -10,8 +10,8 @@ const {Log} = require('./Log.js');
  *   characters.
  */
 function fractionToKey(frac) {
-    // SHA 256 hashes are 64-digit hexadecimal numbers. The largest possible SHA
-    // 256 hash is 2^256 - 1.
+  // SHA 256 hashes are 64-digit hexadecimal numbers. The largest possible SHA
+  // 256 hash is 2^256 - 1.
 
   if (frac < 0 || frac > 1) {
     throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
@@ -21,13 +21,13 @@ function fractionToKey(frac) {
   const inDecimal = Math.floor(frac * mult);
   let hexDigits = inDecimal.toString(16);
   if (hexDigits.length < 64) {
-        // Left pad with zeroes
-        // If N zeroes are needed, generate an array of nulls N+1 elements long,
-        // and inserts zeroes between each null.
+    // Left pad with zeroes
+    // If N zeroes are needed, generate an array of nulls N+1 elements long,
+    // and inserts zeroes between each null.
     hexDigits = Array(64 - hexDigits.length + 1).join('0') + hexDigits;
   }
 
-    // Saturate at 2**256 - 1
+  // Saturate at 2**256 - 1
   if (hexDigits.length > 64) {
     hexDigits = Array(65).join('f');
   }
@@ -36,16 +36,16 @@ function fractionToKey(frac) {
 }
 
 function hex(buffer) {
-  var hexCodes = [];
-  var view = new DataView(buffer);
-  for (var i = 0; i < view.byteLength; i += 4) {
+  let hexCodes = [];
+  let view = new DataView(buffer);
+  for (let i = 0; i < view.byteLength; i += 4) {
     // Using getUint32 reduces the number of iterations needed (we process 4 bytes each time)
-    var value = view.getUint32(i);
+    let value = view.getUint32(i);
     // toString(16) will give the hex representation of the number without padding
-    var stringValue = value.toString(16);
+    let stringValue = value.toString(16);
     // We use concatenation and slice for padding
-    var padding = '00000000';
-    var paddedValue = (padding + stringValue).slice(-padding.length);
+    let padding = '00000000';
+    let paddedValue = (padding + stringValue).slice(-padding.length);
     hexCodes.push(paddedValue);
   }
 

--- a/lib/stableSample.js
+++ b/lib/stableSample.js
@@ -1,4 +1,7 @@
-const Sha256 = require('sha.js/sha256');
+const {Cu} = require('chrome');
+Cu.importGlobalProperties(['crypto', 'TextEncoder']);
+
+const {Log} = require('./Log.js');
 
 /**
  * Map from the range [0, 1] to [0, max(sha256)].
@@ -14,7 +17,7 @@ function fractionToKey(frac) {
     throw new Error(`frac must be between 0 and 1 inclusive (got ${frac})`);
   }
 
-  const mult = 2 * 256 - 1;
+  const mult = Math.pow(2, 256) - 1;
   const inDecimal = Math.floor(frac * mult);
   let hexDigits = inDecimal.toString(16);
   if (hexDigits.length < 64) {
@@ -32,16 +35,43 @@ function fractionToKey(frac) {
   return hexDigits;
 }
 
-exports.stableSample = function(input, rate) {
-  const hasher = new Sha256();
-  hasher.update(JSON.stringify(input));
-
-  const samplePoint = fractionToKey(rate);
-  const inputHash = hasher.digest('hex');
-
-  if (samplePoint.length !== 64 || inputHash.length !== 64) {
-    throw new Error('Unexpected hash length');
+function hex(buffer) {
+  var hexCodes = [];
+  var view = new DataView(buffer);
+  for (var i = 0; i < view.byteLength; i += 4) {
+    // Using getUint32 reduces the number of iterations needed (we process 4 bytes each time)
+    var value = view.getUint32(i);
+    // toString(16) will give the hex representation of the number without padding
+    var stringValue = value.toString(16);
+    // We use concatenation and slice for padding
+    var padding = '00000000';
+    var paddedValue = (padding + stringValue).slice(-padding.length);
+    hexCodes.push(paddedValue);
   }
 
-  return inputHash < samplePoint;
+  // Join all the hex strings into one
+  return hexCodes.join('');
+}
+
+exports.stableSample = function(input, rate) {
+  const hasher = crypto.subtle;
+
+  return hasher.digest('SHA-256', new TextEncoder('utf-8').encode(JSON.stringify(input)))
+    .then(hash => {
+      const inputHash = hex(hash);
+      const samplePoint = fractionToKey(rate);
+
+      Log.info(`SamplePoint: ${samplePoint} -> length: ${samplePoint.length}`);
+      Log.info(`inputHash: ${inputHash} -> length: ${inputHash.length}`);
+
+      if (samplePoint.length !== 64 || inputHash.length !== 64) {
+        throw new Error('Unexpected hash length');
+      }
+
+      return inputHash < samplePoint;
+
+    })
+    .catch(error => {
+      Log.error(`Error: ${error}`);
+    });
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "woodchipper": "0.9.1"
   },
   "dependencies": {
-    "jexl": "1.1.3"
+    "jexl": "1.1.3",
+    "sha.js": "2.4.5"
   }
 }

--- a/test/test-env-expressions.js
+++ b/test/test-env-expressions.js
@@ -32,4 +32,19 @@ exports['test dates are comparable'] = promiseTest(assert => {
   ]);
 });
 
+exports['test has a stable sample transform'] = promiseTest(assert => {
+  return EnvExpressions.eval('["test"]|stableSample(0.999)')
+  .then(val => assert.ok(val));
+});
+
+exports['test returns true for matching samples'] = promiseTest(assert => {
+  return EnvExpressions.eval('["test"]|stableSample(1)')
+  .then(val => assert.equal(val, true));
+});
+
+exports['test returns false for matching samples'] = promiseTest(assert => {
+  return EnvExpressions.eval('["test"]|stableSample(0)')
+  .then(val => assert.equal(val, false));
+});
+
 testRunner.run(exports);


### PR DESCRIPTION
Just having trouble with the dependencies here. Using `sha.js`, I initially had problems where the addon couldn't find the `inherits` module that it required. I whitelisted the `inherits` module in `.jpmignore` which solved that problem. 

But then I got an error about not being able to find the `util` dependency that was required in `inherits`. It didn't get installed automatically with `npm install`, so I tried doing an `npm install --save util` and whitelisting it in `.jpmignore` but that didn't work.

I (temporarily and hackily) worked around needing `util` by editing `sha.js/sha256.js` to require `inherits/inherits_browser` instead, which got me a little further.

My next error was `Buffer is not defined`, when trying to check the filter expression. Buffer is a required dependency of `sha.js`. I also tried whitelisting this dependency in `.jpmignore` but with no success.