### PR TITLE
Cleanup UI and events on unLoad/disable

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ exports.main = function() {
 };
 
 exports.onUnload = function() {
+  RecipeRunner.cleanup();
   SelfRepairInteraction.enableSelfRepair();
 };

--- a/lib/NormandyDriver.js
+++ b/lib/NormandyDriver.js
@@ -13,7 +13,7 @@ const {Heartbeat} = require('./Heartbeat.js');
 const actionLogger = Log.makeNamespace('actions');
 
 // Spec: https://raw.githubusercontent.com/mozilla/normandy-actions/9d6406f21f9025602c87754209de9fd675cc4871/docs/driver.rst
-exports.NormandyDriver = function(sandbox, extraContext) {
+exports.NormandyDriver = function(recipeRunner, sandbox, extraContext) {
   return {
     testing: true,
 
@@ -46,6 +46,8 @@ exports.NormandyDriver = function(sandbox, extraContext) {
         testing: this.testing,
         sandbox: sandbox,
       });
+
+      recipeRunner.heartbeatNotifications.push(heartbeat);
 
       let sandboxedEvents = Cu.cloneInto(heartbeat.events, sandbox, {cloneFunctions: true});
 

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -125,13 +125,28 @@ exports.RecipeRunner = {
       window.registerAction = registerAction;
     `;
 
-    const driver = new NormandyDriver(sandbox, extraContext);
+    const driver = new NormandyDriver(this, sandbox, extraContext);
     sandbox.sandboxedDriver = Cu.cloneInto(driver, sandbox, {cloneFunctions: true});
     sandbox.sandboxedRecipe = Cu.cloneInto(recipe, sandbox);
     sandbox.window = Cu.cloneInto({}, sandbox);
+    sandbox.navigator = Cu.cloneInto({}, sandbox);
 
     Cu.evalInSandbox(registerActionScript, sandbox);
     Cu.evalInSandbox(actionScript, sandbox);
     Log.debug('Finished running action');
   }),
+
+  heartbeatNotifications: [],
+
+  cleanup() {
+    if (this.heartbeatNotifications.length) {
+      this.heartbeatNotifications.forEach(heartbeat => {
+        let notice = heartbeat.notificationBox.getNotificationWithValue(`heartbeat-${heartbeat.options.flowId}`);
+        if (notice) {
+          heartbeat.notificationBox.removeNotification(notice);
+        }
+        this.heartbeatNotifications.shift();
+      });
+    }
+  }
 };

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -129,7 +129,6 @@ exports.RecipeRunner = {
     sandbox.sandboxedDriver = Cu.cloneInto(driver, sandbox, {cloneFunctions: true});
     sandbox.sandboxedRecipe = Cu.cloneInto(recipe, sandbox);
     sandbox.window = Cu.cloneInto({}, sandbox);
-    sandbox.navigator = Cu.cloneInto({}, sandbox);
 
     Cu.evalInSandbox(registerActionScript, sandbox);
     Cu.evalInSandbox(actionScript, sandbox);

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -144,8 +144,9 @@ exports.RecipeRunner = {
         if (notice) {
           heartbeat.notificationBox.removeNotification(notice);
         }
-        this.heartbeatNotifications.shift();
       });
+
+      this.heartbeatNotifications = [];
     }
   }
 };


### PR DESCRIPTION
Right now this just removes the UI element from the window when we disable/unload the addon.

I'm selecting the notification element by Id (https://github.com/mozilla/normandy-addon/blob/48ee9dad3a3a56700b724b77ba4d9086f0ae6ce3/index.js#L16) which means there's a chance this notification could be for something unrelated to heartbeat. I can add an additional qualifier by checking if there is a `heartbeat` class on the element, but I'm assuming we might be using this notification box for other types of actions in the future? Is checking for the class too specific? Is selecting by ID too generic?

As for cleaning up events, I'm not actually sure what kind of listeners we are setting. If I try to log anything in `emit` or `on` in [EventEmitter.js](https://github.com/mozilla/normandy-addon/blob/master/lib/EventEmitter.js), it doesn't look like it's actually ever doing anything? Or is this [heartbeat-events](https://github.com/mozilla/normandy-addon/tree/heartbeat-events) a more recent branch that needs to be merged? I looked into just [nuking the recipe sandbox](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.Sandbox) but we'd need to be able to get a reference to all the recipe sandboxes in `index.js` so I'm not sure if that's the way to go. 
