### PR TITLE
Fix Learn More href and message property name

### DIFF
--- a/lib/Heartbeat.js
+++ b/lib/Heartbeat.js
@@ -128,15 +128,6 @@ exports.Heartbeat = class {
 
     frag.appendChild(ratingContainer);
 
-    if (this.options.learnMoreMessage && this.options.learnMoreURL) {
-      let learnMore = this.chromeWindow.document.createElement('label');
-      learnMore.className = 'text-link';
-      learnMore.href = this.options.learnMoreURL;
-      learnMore.setAttribute('value', this.options.learnMoreMessage);
-      learnMore.addEventListener('click', () => this.maybeNotifyHeartbeat('LearnMore'));
-      frag.appendChild(learnMore);
-    }
-
     this.messageImage = this.chromeWindow.document.getAnonymousElementByAttribute(this.notice, 'anonid', 'messageImage');
     this.messageImage.classList.add('heartbeat', 'pulse-onshow');
 
@@ -152,6 +143,16 @@ exports.Heartbeat = class {
     this.messageText.flex = 0;
     let leftSpacer = this.messageText.nextSibling;
     leftSpacer.flex = 0;
+
+    // Add Learn More Link
+    if (this.options.learnMoreMessage && this.options.learnMoreURL) {
+      let learnMore = this.chromeWindow.document.createElement('label');
+      learnMore.className = 'text-link';
+      learnMore.href = this.options.learnMoreURL;
+      learnMore.setAttribute('value', this.options.learnMoreMessage);
+      learnMore.addEventListener('click', () => this.maybeNotifyHeartbeat('LearnMore'));
+      frag.appendChild(learnMore);
+    }
 
     // Append the fragment and apply the styling
     this.notice.appendChild(frag);

--- a/lib/Heartbeat.js
+++ b/lib/Heartbeat.js
@@ -37,7 +37,7 @@ const PREF_SURVEY_DURATION = 'browser.uitour.surveyDuration';
  * @param {String} [options.engagementURL=null]
  *        The engagement URL to open in a new tab once user has engaged. If this is null
  *        or invalid, no new tab is opened.
- * @param {String} [options.learnMoreLabel=null]
+ * @param {String} [options.learnMoreMessage=null]
  *        The label of the learn more link. No link will be shown if this is null.
  * @param {String} [options.learnMoreURL=null]
  *        The learn more URL to open when clicking on the learn more link. No learn more
@@ -128,11 +128,11 @@ exports.Heartbeat = class {
 
     frag.appendChild(ratingContainer);
 
-    if (this.options.learnMoreLabel && this.options.learnMoreURL) {
+    if (this.options.learnMoreMessage && this.options.learnMoreURL) {
       let learnMore = this.chromeWindow.document.createElement('label');
       learnMore.className = 'text-link';
-      learnMore.href = learnMore;
-      learnMore.setAttribute('value', this.options.learnMoreLabel);
+      learnMore.href = this.options.learnMoreURL;
+      learnMore.setAttribute('value', this.options.learnMoreMessage);
       learnMore.addEventListener('click', () => this.maybeNotifyHeartbeat('LearnMore'));
       frag.appendChild(learnMore);
     }


### PR DESCRIPTION
The href value for the learn more link was set to an element, and the attribute names were off (`LearnMoreLabel -> LearnMoreMessage`). This fixes both of those things.

Although, it looks to me like the learn more link is showing up on the left. It's supposed to be on the right, isn't it? (Sorry all my label values are exactly the same, but the blue link is the learn more element). I couldn't see any differences in the styling/classes we set in our implementation vs. UITour that would make it show up like this. Any thoughts?

<img width="1136" alt="screen shot 2016-08-22 at 5 47 02 pm" src="https://cloud.githubusercontent.com/assets/856935/17872929/9e95befe-6890-11e6-9091-bfa03b6dc5b7.png">
