### PR TITLE
Expect bare signatures from Normandy API, not content-signature encoded signatures

### DIFF
--- a/lib/NormandyApi.js
+++ b/lib/NormandyApi.js
@@ -45,11 +45,12 @@ exports.NormandyApi = {
       }
 
       let certChain = (yield Http.get({url: x5u})).text;
+      let builtSignature = `x5u="${x5u}";p384ecdsa=${signature}`;
 
       const verifier = Cc['@mozilla.org/security/contentsignatureverifier;1']
         .createInstance(Ci.nsIContentSignatureVerifier);
 
-      if (!verifier.verifyContentSignature(serialized, signature, certChain, 'normandy.content-signature.mozilla.org')) {
+      if (!verifier.verifyContentSignature(serialized, builtSignature, certChain, 'normandy.content-signature.mozilla.org')) {
         throw new Error('Recipe signature is not valid');
       } else {
         verifiedRecipes.push(recipe);


### PR DESCRIPTION
This is related to the change from mozilla/normandy#264.