### PR TITLE
Delay recipe loading after startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,14 @@ exports.main = function() {
   }
 };
 
-// Called when the addon is uninstalled or disabled.
-exports.onUnload = function() {
+// Called when Firefox is shut down, or when the addon is uninstalled or disabled.
+exports.onUnload = function(reason) {
   if (didInit) {
     RecipeRunner.cleanup();
     didInit = false;
   }
-  SelfRepairInteraction.enableSelfRepair();
+
+  if (reason === 'uninstall' || reason === 'disable') {
+    SelfRepairInteraction.enableSelfRepair();
+  }
 };

--- a/lib/Heartbeat.js
+++ b/lib/Heartbeat.js
@@ -72,7 +72,7 @@ exports.Heartbeat = class {
 
           this.userEngaged(new Map([
             ['type', 'button'],
-            ['flowid', this.options.flowId]
+            ['flowid', this.options.flowId],
           ]));
 
           // Return true so that the notification bar doesn't close itself since
@@ -278,7 +278,7 @@ exports.Heartbeat = class {
       this.chromeWindow.gBrowser.selectedTab =
         this.chromeWindow.gBrowser.addTab(engagementURL.toString(), {
           owner: this.chromeWindow.gBrowser.selectedTab,
-          relatedToCurrent: true
+          relatedToCurrent: true,
         });
     }
 

--- a/lib/NormandyApi.js
+++ b/lib/NormandyApi.js
@@ -1,11 +1,9 @@
 const {Cu, Cc, Ci} = require('chrome');
-Cu.import('resource://gre/modules/Preferences.jsm'); /* globals Preferences */
 Cu.import('resource://gre/modules/Task.jsm'); /* globals Task */
 const {CanonicalJSON} = Cu.import('resource://gre/modules/CanonicalJSON.jsm');
 const {prefs} = require('sdk/simple-prefs');
 
 const {Http} = require('./Http.js');
-const {Log} = require('./Log.js');
 
 exports.NormandyApi = {
   apiCall(method, endpoint, data={}) {

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -15,9 +15,19 @@ const STARTUP_DELAY_MS = 0;
 
 exports.RecipeRunner = {
   init() {
-    if (this.checkPrefs()) {
-      setTimeout(this.start.bind(this), STARTUP_DELAY_MS);
+    if (!this.checkPrefs()) {
+      return;
     }
+
+    let delay;
+    if (prefs.dev_mode) {
+      delay = 0;
+    } else {
+      // startup delay is in seconds
+      delay = prefs.startup_delay * 1000;
+    }
+
+    setTimeout(this.start.bind(this), delay);
   },
 
   checkPrefs() {

--- a/lib/RecipeRunner.js
+++ b/lib/RecipeRunner.js
@@ -10,9 +10,6 @@ const {NormandyDriver} = require('./NormandyDriver.js');
 const {EnvExpressions} = require('./EnvExpressions.js');
 const {NormandyApi} = require('./NormandyApi.js');
 
-// const STARTUP_DELAY_MS = 5000;
-const STARTUP_DELAY_MS = 0;
-
 exports.RecipeRunner = {
   init() {
     if (!this.checkPrefs()) {
@@ -158,5 +155,5 @@ exports.RecipeRunner = {
 
       this.heartbeatNotifications = [];
     }
-  }
+  },
 };

--- a/lib/SelfRepairInteraction.js
+++ b/lib/SelfRepairInteraction.js
@@ -3,26 +3,30 @@ const {Cu} = require('chrome');
 Cu.import('resource://gre/modules/Preferences.jsm');
 const {Log} = require('./Log.js');
 
+PREF_SELF_SUPPORT_ENABLED = 'browser.selfsupport.enabled';
+
 exports.SelfRepairInteraction = {
   enableSelfRepair() {
-    if (!Preferences.get('browser.selfsupport.enabled', true)) {
+    if (!this.isEnabled()) {
       Log.info('Reenabling Self Repair');
       this.setSelfRepair(true);
     }
   },
 
   disableSelfRepair() {
-    if (Preferences.get('browser.selfsupport.enabled', true)) {
+    if (this.isEnabled()) {
       Log.info('Disabling Self Repair');
       this.setSelfRepair(false);
     }
   },
 
   setSelfRepair(enabled) {
-    Preferences.set('browser.selfsupport.enabled', enabled);
+    Preferences.set(PREF_SELF_SUPPORT_ENABLED, enabled);
   },
 
   isEnabled() {
-    return Preferences.get('browser.selfsupport.enabled', true);
+    let enabled = Preferences.get(PREF_SELF_SUPPORT_ENABLED);
+    Log.debug('SelfRepairInteraction.isEnabled() ->', enabled);
+    return enabled === true || enabled === undefined;
   },
 };

--- a/lib/SelfRepairInteraction.js
+++ b/lib/SelfRepairInteraction.js
@@ -3,7 +3,7 @@ const {Cu} = require('chrome');
 Cu.import('resource://gre/modules/Preferences.jsm');
 const {Log} = require('./Log.js');
 
-PREF_SELF_SUPPORT_ENABLED = 'browser.selfsupport.enabled';
+const PREF_SELF_SUPPORT_ENABLED = 'browser.selfsupport.enabled';
 
 exports.SelfRepairInteraction = {
   enableSelfRepair() {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
       "title": "Developer Mode",
       "type": "bool",
       "value": false
+    }, {
+      "name": "startup_delay",
+      "title": "Startup Delay",
+      "description": "Number of seconds to wait after startup before running recipes",
+      "type": "integer",
+      "value": 300
     }
   ],
   "devDependencies": {


### PR DESCRIPTION
I also discovered problems with delaying loads after disabling self-repair. `onUnload` was being called on Firefox shutdown, so in non-dev mode, the addon was never actually being enabled.

r?