### PR TITLE
Stub shield study consent page

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -14,4 +14,6 @@ globals:
   exports: true
   uneval: false
   crypto: true
+  document: true
+  self: true
   TextEncoder: true

--- a/.jpmignore
+++ b/.jpmignore
@@ -8,3 +8,4 @@
 !/LICENSE
 !/README.md
 !/package.json
+!/chrome.manifest

--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+resource  shield-recipe-client         data/

--- a/data/consent-page.css
+++ b/data/consent-page.css
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@import url("chrome://global/skin/in-content/common.css");
+
+html {
+  height: 100%;
+}
+
+body {
+  align-items: stretch;
+  display: flex;
+  justify-content: center;
+  min-height: 100%;
+}
+
+.container {
+  margin: 10vh 0;
+  max-width: 920px;
+  padding: 0 10px;
+}
+
+.title-container {
+  align-items: center;
+  border-bottom: 1px solid var(--in-content-box-border-color);
+  display: flex;
+  margin-bottom: .5em;
+  padding-bottom: 1em;
+  position: relative;
+}
+
+.title {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.title::before {
+  background: url('../images/small-firefox-logo@2x.png') no-repeat left center;
+  background-size: 57px 59px;
+  content: '';
+  display: block;
+  height: 59px;
+  left: -2.3em;
+  position: absolute;
+  top: 0;
+  width: 57px;
+}
+
+.button {
+  height: 40px;
+  margin: 0;
+  padding: 0 15px;
+}
+
+.button:hover {
+  cursor: pointer;
+}
+
+.button.success {
+  background-color: rgb(87, 189, 53);
+}

--- a/data/consent-page.html
+++ b/data/consent-page.html
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+
+<!DOCTYPE html>
+  <html xmlns="http://www.w3.org/1999/xhtml hasBrowserHandlers="true">
+    <head>
+      <meta charset="utf-8" />
+      <title>Participate in SHIELD Studies</title>
+      <link rel="stylesheet" href="consent-page.css" type="text/css" />
+    </head>
+  <body>
+      <div class="container">
+        <div class="title-container">
+          <h1 class="title studyName"></h1>
+          <button id="installAddon" class="addonUrl button primary"></button>
+        </div>
+        <div class="content">
+          <h2 id="what-will-happen-next">What will happen next</h2>
+          <p><strong>If you agree</strong> to participate:</p>
+          <ol>
+          <li>We install <strong class="studyName"></strong>, an add-on that will make the Firefox browser more personal to your usage patterns.</li>
+          <li>Continue using Firefox as you normally would. You may notice changes.</li>
+          <li>After <span class="duration"></span>, the study will end on its own. Your Firefox will go back to normal.</li>
+          <li>We will ask you to fill out a quick <strong>optional survey</strong> to tell us about your experience. The survey should take less than 5 minutes to complete.</li>
+          </ol>
+          <h2 id="leaving-the-study">Leaving the study</h2>
+          <p>The study will expire on its own in <span class="duration"></span>.  You may leave the study early.  To do so, follow these steps:</p>
+          <ol>
+          <li>Type <code>about:addons</code> into the location bar, and press enter.</li>
+          <li>Find <code class="studyName"></code> in the <strong>extensions</strong> list pane.</li>
+          <li>Click the <code>remove</code> button.</li>
+          <li>If you opt out of the study early we will ask you to fill out a survey. We’re interested in hearing about your experience, even if you didn’t participate in the entire study.</li>
+          </ol>
+          <p>Opting out of a study does not prevent you from participating in future studies.</p>
+          <h2 id="your-privacy">Your privacy</h2>
+          <h3 id="all-shield-studies">All Shield Studies</h3>
+          <p>Every Shield Study collects data about important study events, such as install, uninstall, daily usage, and end of study. Studies also include an optional survey.</p>
+          <p>This data is associated with <a href="https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/index.html">Firefox Telemetry collection</a>.</p>
+          <h3 id="this-particular-study">This Particular Study</h3>
+          <p>In addition to the data collected by all Shield Studies and your voluntary answers to the followup survey, here are the <strong>key things you should know</strong> about what is happening when you participate in this study:</p>
+          <ul>
+          <li>We collect basic usage data regarding your interaction with the experimental add-on.</li>
+          <li>We collect data around your visits to <a href="https://github.com/mozilla/addon-recommendation-shield-study/blob/master/sites.txt">certain popular websites</a> in order to provide a more customized Firefox experience.</li>
+          <li>As you would expect, we do not collect any information when you are in private browsing mode.</li>
+          </ul>
+          <h2 id="you-help-make-firefox-better">You help make Firefox better</h2>
+          <p>At Mozilla, we pride ourselves on building products for you, the user! That’s why we need your help.  You help us by letting us observe how you use new features and by telling us your opinions about them.</p>
+          <p>By participating in this study, you will help us make better decisions on your behalf and directly shape the future of Firefox.</p>
+          <h2 id="brought-to-you-by">Brought to you by</h2>
+          <p class="authors"></p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/data/consent-page.js
+++ b/data/consent-page.js
@@ -1,0 +1,26 @@
+const studyValues = [
+  'studyName',
+  'addonName',
+  'duration',
+  'authors',
+];
+
+studyValues.forEach(property => {
+  const elems = document.getElementsByClassName(property);
+  [].forEach.call(elems, elem => {
+    elem.innerText = self.options[property];
+  });
+});
+
+const installAddonButton = document.getElementById('installAddon');
+installAddonButton.innerText = self.options.buttonText || `Try ${self.options.addonName}`;
+
+installAddonButton.addEventListener('click', () => {
+  self.port.emit('optedIntoStudy', 'Enabled study');
+  installAddonButton.innerText = 'Installing Addon...';
+});
+
+self.port.on('addonInstalled', () => {
+  installAddonButton.innerText = self.options.thankYouText || 'Thank you for participating!';
+  installAddonButton.classList.add('success');
+});

--- a/lib/NormandyDriver.js
+++ b/lib/NormandyDriver.js
@@ -1,5 +1,7 @@
 const {uuid} = require('sdk/util/uuid');
+const tabs = require('sdk/tabs');
 const {Cu} = require('chrome');
+let {AddonManager} = Cu.import('resource://gre/modules/AddonManager.jsm', {});
 Cu.import('resource://gre/modules/Services.jsm'); /* globals Services: false */
 Cu.import('resource://gre/modules/Preferences.jsm'); /* globals Preferences */
 Cu.import('resource:///modules/ShellService.jsm'); /* globals ShellService: false */
@@ -123,6 +125,31 @@ exports.NormandyDriver = function(recipeRunner, sandbox, extraContext) {
 
     envExpression(expr) {
       return EnvExpressions.eval(expr, extraContext);
+    },
+
+    showStudyConsentPage(options) {
+      tabs.open({
+        url: 'resource://shield-recipe-client/consent-page.html',
+        onReady: tab => {
+          const worker = tab.attach({
+            contentScriptFile: 'resource://shield-recipe-client/consent-page.js',
+            contentScriptOptions: options,
+          });
+
+          worker.port.on('optedIntoStudy', () => {
+            AddonManager.getInstallForURL(
+              options.addonUrl, addonInstall => {
+                addonInstall.addListener({
+                  onInstallEnded: () => {
+                    worker.port.emit('addonInstalled');
+                  },
+                });
+                addonInstall.install();
+              },
+              'application/x-xpinstall');
+          });
+        },
+      });
     },
   };
 };


### PR DESCRIPTION
Opens a new tab with a consent page for participating in a SHIELD study, with a button that installs the study addon when users opt-in. Additional work needs to be done here (check if addon is already installed, prompt to show consent page with heartbeat UI bar, determine how flexible the consent page copy needs to be, etc.) but this is a start.