### PR TITLE
Rewrite driver Storage to use JSONFile.jsm

### DIFF
--- a/lib/Storage.js
+++ b/lib/Storage.js
@@ -1,87 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
 const {Cu} = require('chrome');
-var {indexedDB} = require('sdk/indexed-db');
+Cu.import('resource://gre/modules/XPCOMUtils.jsm'); /* global XPCOMUtils */
 
-exports.Storage = function(prefix, sandbox=null) {
-  if (sandbox === null) {
-    sandbox = {Promise};
+XPCOMUtils.defineLazyModuleGetter(this, 'JSONFile',
+                                  'resource://gre/modules/JSONFile.jsm'); /* global JSONFile */
+
+XPCOMUtils.defineLazyModuleGetter(this, 'OS',
+                                  'resource://gre/modules/osfile.jsm'); /* global OS */
+XPCOMUtils.defineLazyModuleGetter(this, 'Task',
+                                  'resource://gre/modules/Task.jsm'); /* global Task */
+
+const {Log} = require('./Log.js');
+
+let storePromise;
+
+function loadStorage() {
+  if (storePromise === undefined) {
+    let path = OS.Path.join(OS.Constants.Path.profileDir, 'recipe-client.json');
+    let storage = new JSONFile({path});
+    storePromise = Task.spawn(function* () {
+      yield storage.load();
+      return storage;
+    });
   }
+  return storePromise;
+}
 
-  const idbPromise = new sandbox.Promise((resolve, reject) => {
-    let request = indexedDB.open('normandy', 1);
-    request.onsuccess = event => resolve(event.target.result);
-    request.onerror = err => reject(err);
-
-    request.onupgradeneeded = event => {
-      var db = event.target.result;
-      db.createObjectStore('storage', {keyPath: 'key'});
-    };
-  });
-
-  function makeKey(suffix) {
-    return `${prefix}.${suffix}`;
+exports.Storage = function(prefix, sandbox) {
+  if (!sandbox) {
+    throw new Error('No sandbox passed');
   }
 
   const storageInterface = {
+    /**
+     * Sets an item in the prefixed storage.
+     * @returns {Promise}
+     * @resolves With the stored value, or null.
+     * @rejects Javascript exception.
+     */
     getItem(keySuffix) {
-      return idbPromise.then(db => {
-        return new sandbox.Promise((resolve, reject) => {
-          let key = makeKey(keySuffix);
-          let transaction = db.transaction(['storage'], 'readonly');
-          let request = transaction.objectStore('storage').get(key);
-          request.onsuccess = event => {
-            if (event.target.result) {
-              resolve(event.target.result.value);
-            } else {
-              resolve(null);
-            }
-          };
-          request.onerror = err => reject(err);
+      return loadStorage()
+        .then(store => {
+          let namespace = store.data[prefix] || {};
+          const value = namespace[keySuffix] || null;
+          return sandbox.Promise.resolve(Cu.cloneInto(value, sandbox));
+        })
+        .catch(err => {
+          Log.error(err);
+          throw new Error(err.toString());
         });
-      });
-    },
-
-    setItem(keySuffix, value) {
-      return idbPromise.then(db => {
-        return new sandbox.Promise((resolve, reject) => {
-          let key = makeKey(keySuffix);
-          let transaction = db.transaction(['storage'], 'readwrite');
-          let request = transaction.objectStore('storage').put({key, value});
-          request.onsuccess = () => resolve();
-          request.onerror = err => reject(err);
-        });
-      });
-    },
-
-    removeItem(keySuffix) {
-      return idbPromise.then(db => {
-        return new sandbox.Promise((resolve, reject) => {
-          let key = makeKey(keySuffix);
-          let transaction = db.transaction(['storage'], 'readwrite');
-          let request = transaction.objectStore('storage').delete(key);
-          request.onsuccess = () => resolve();
-          request.onerror = err => reject(err);
-        });
-      });
     },
 
     /**
-     * Clears all storage for all recipes.
-     * @promise {undefined} returns when the storage is cleared.
+     * Sets an item in the prefixed storage.
+     * @returns {Promise}
+     * @resolves When the operation is completed succesfully
+     * @rejects Javascript exception.
+     */
+    setItem(keySuffix, value) {
+      return loadStorage()
+        .then(store => {
+          if (!(prefix in store.data)) {
+            store.data[prefix] = {};
+          }
+          store.data[prefix][keySuffix] = value;
+          return store.save();
+        })
+        .then(() => {
+          return sandbox.Promise.resolve();
+        })
+        .catch(err => {
+          Log.error(err);
+          throw new Error(err.toString());
+        });
+    },
+
+    /**
+     * Removes a single item from the prefixed storage.
+     * @returns {Promise}
+     * @resolves When the operation is completed succesfully
+     * @rejects Javascript exception.
+     */
+    removeItem(keySuffix) {
+      return loadStorage()
+        .then(store => {
+          if (!(prefix in store.data)) {
+            return Promise.resolve();
+          }
+          delete store.data[prefix][keySuffix];
+          return store.save();
+        })
+        .then(() => {
+          return sandbox.Promise.resolve();
+        })
+        .catch(err => {
+          Log.error(err);
+          throw new Error(err.toString());
+        });
+    },
+
+    /**
+     * Clears all storage for the prefix.
+     * @returns {Promise}
+     * @resolves When the operation is completed succesfully
+     * @rejects Javascript exception.
      */
     clear() {
-      return idbPromise.then(db => {
-        return new sandbox.Promise((resolve, reject) => {
-          let transaction = db.transaction(['storage'], 'readwrite');
-          let request = transaction.objectStore('storage').clear();
-          request.onsuccess = () => resolve();
-          request.onerror = err => reject(err);
+      return loadStorage()
+        .then(store => {
+          store.data[prefix] = {};
+          return store.save();
+        })
+        .then(() => {
+          return sandbox.Promise.resolve();
+        })
+        .catch(err => {
+          Log.error(err);
+          throw new Error(err.toString());
         });
-      });
     },
   };
 
-  let sandboxedStorageInterfaces = Cu.cloneInto(storageInterface, sandbox, {
+  return Cu.cloneInto(storageInterface, sandbox, {
     cloneFunctions: true,
   });
-  return sandboxedStorageInterfaces;
 };

--- a/test/test-storage.js
+++ b/test/test-storage.js
@@ -7,7 +7,7 @@ const {promiseTest} = require('./utils.js');
 let store;
 
 exports['test set and get'] = promiseTest(assert => {
-  let store = new Storage('prefix');
+  let store = new Storage('prefix', {Promise});
 
   return store.setItem('key', 'value')
   .then(() => store.getItem('key'))
@@ -17,13 +17,13 @@ exports['test set and get'] = promiseTest(assert => {
 });
 
 exports["test value don't exist before set"] = promiseTest(assert => {
-  let store = new Storage('prefix');
+  let store = new Storage('prefix', {Promise});
   return store.getItem('absent')
   .then(value => assert.equal(value, null));
 });
 
 exports['test set and remove and get'] = promiseTest(assert => {
-  let store = new Storage('prefix');
+  let store = new Storage('prefix', {Promise});
 
   return store.setItem('removed', 'value')
   .then(() => store.removeItem('removed'))
@@ -32,7 +32,7 @@ exports['test set and remove and get'] = promiseTest(assert => {
 });
 
 exports['test tests are independent 1 of 2'] = promiseTest(assert => {
-  let store = new Storage('prefix');
+  let store = new Storage('prefix', {Promise});
   return store.getItem('counter')
   .then(value => store.setItem('counter', (value || 0) + 1))
   .then(() => store.getItem('counter'))
@@ -40,7 +40,7 @@ exports['test tests are independent 1 of 2'] = promiseTest(assert => {
 });
 
 exports['test tests are independent 2 of 2'] = promiseTest(assert => {
-  let store = new Storage('prefix');
+  let store = new Storage('prefix', {Promise});
   return store.getItem('counter')
   .then(value => store.setItem('counter', (value || 0) + 1))
   .then(() => store.getItem('counter'))
@@ -48,7 +48,7 @@ exports['test tests are independent 2 of 2'] = promiseTest(assert => {
 });
 
 before(exports, () => {
-  store = new Storage('prefix');
+  store = new Storage('prefix', {Promise});
 });
 
 after(exports, (name, assert, done) => {


### PR DESCRIPTION
This is one less SDK dependency, and should be easier to debug than indexedDB.

Note: JSONFile, although recommended by Real Firefox Developers™, is only available in Nightly right now. This makes it a bit harder for S&I to test.