### PR TITLE
mozilla/normandy#289: Add sync device counts to the driver.

### DIFF
--- a/lib/NormandyDriver.js
+++ b/lib/NormandyDriver.js
@@ -88,6 +88,9 @@ exports.NormandyDriver = function(recipeRunner, sandbox, extraContext) {
         isDefaultBrowser: ShellService.isDefaultBrowser() || null,
         searchEngine: Services.search.defaultEngine.identifier,
         syncSetup: Services.prefs.prefHasUserValue('services.sync.username'),
+        syncDesktopDevices: Preferences.get('services.sync.clients.devices.desktop', 0),
+        syncMobileDevices: Preferences.get('services.sync.clients.devices.mobile', 0),
+        syncTotalDevices: Preferences.get('services.sync.numClients', 0),
         plugins: {}, // TODO
         doNotTrack: false, // TODO
       };

--- a/test/test-driver.js
+++ b/test/test-driver.js
@@ -1,7 +1,10 @@
 const {Cu} = require('chrome');
 const testRunner = require('sdk/test');
 const {before, after} = require('sdk/test/utils');
+Cu.import('resource://gre/modules/Task.jsm'); /* globals Task */
+Cu.import('resource://gre/modules/Preferences.jsm'); /* globals Preferences */
 
+const {promiseTest} = require('./utils.js');
 const {NormandyDriver} = require('../lib/NormandyDriver.js');
 
 let sandbox;
@@ -12,9 +15,39 @@ exports['test uuid'] = assert => {
   assert.notEqual(/^[a-f0-9-]{36}$/.exec(uuid), null);
 };
 
+exports['test sync device counts'] = promiseTest(assert => Task.spawn(function*() {
+  Preferences.set('services.sync.clients.devices.desktop', 4);
+  Preferences.set('services.sync.clients.devices.mobile', 5);
+  Preferences.set('services.sync.numClients', 9);
+  let client = yield driver.client();
+  assert.equal(client.syncMobileDevices, 5);
+  assert.equal(client.syncDesktopDevices, 4);
+  assert.equal(client.syncTotalDevices, 9);
+
+  Preferences.reset('services.sync.clients.devices.desktop');
+  client = yield driver.client();
+  assert.equal(client.syncMobileDevices, 5);
+  assert.equal(client.syncDesktopDevices, 0);
+  assert.equal(client.syncTotalDevices, 9);
+
+  Preferences.reset('services.sync.clients.devices.mobile');
+  client = yield driver.client();
+  assert.equal(client.syncMobileDevices, 0);
+  assert.equal(client.syncDesktopDevices, 0);
+  assert.equal(client.syncTotalDevices, 9);
+
+  Preferences.reset('services.sync.numClients');
+  client = yield driver.client();
+  assert.equal(client.syncMobileDevices, 0);
+  assert.equal(client.syncDesktopDevices, 0);
+  assert.equal(client.syncTotalDevices, 0);
+}));
+
 before(exports, () => {
   sandbox = new Cu.Sandbox(null);
-  driver = new NormandyDriver(sandbox, {});
+  // Passing a fake reciperRunner for now; this should either be mocked
+  // properly or removed as an argument to the driver.
+  driver = new NormandyDriver({}, sandbox, {});
 });
 
 after(exports, () => {


### PR DESCRIPTION
This implicitly adds it to the filter context as well. Almost entirely lifted from the Firefox patch to UITour for this.

r?
