### PR TITLE
Fix un-imported fetch use in NormandyApi.jsm.

### DIFF
--- a/lib/NormandyApi.jsm
+++ b/lib/NormandyApi.jsm
@@ -10,6 +10,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://gre/modules/CanonicalJSON.jsm");
 Cu.import("resource://gre/modules/Log.jsm");
+Cu.importGlobalProperties(["fetch"]); /* globals fetch */
 
 this.EXPORTED_SYMBOLS = ["NormandyApi"];
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     is: false,
     isnot: false,
     ok: false,
+    SpecialPowers: false,
   },
   rules: {
     "spaced-comment": 2,

--- a/test/browser.ini
+++ b/test/browser.ini
@@ -3,3 +3,6 @@
 [browser_EventEmitter.js]
 [browser_Storage.js]
 [browser_Heartbeat.js]
+[browser_NormandyApi.js]
+  support-files =
+    test_server.sjs

--- a/test/browser_NormandyApi.js
+++ b/test/browser_NormandyApi.js
@@ -1,0 +1,17 @@
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://shield-recipe-client/lib/NormandyApi.jsm", this);
+
+add_task(function* () {
+  // Point the add-on to the test server.
+  SpecialPowers.setCharPref(
+    "extensions.shield-recipe-client.api_url",
+    "http://mochi.test:8888/browser/browser/extensions/shield-recipe-client/test",
+  );
+
+  // Test that NormandyApi can fetch from the test server.
+  const response = yield NormandyApi.get("test_server.sjs");
+  const data = yield response.json();
+  Assert.deepEqual(data, {test: "data"}, "NormandyApi returned incorrect server data.");
+});

--- a/test/test_server.sjs
+++ b/test/test_server.sjs
@@ -1,0 +1,8 @@
+function handleRequest(request, response) {
+  // Allow cross-origin, so you can XHR to it!
+  response.setHeader("Access-Control-Allow-Origin", "*", false);
+  // Avoid confusing cache behaviors
+  response.setHeader("Cache-Control", "no-cache", false);
+  response.setHeader("Content-Type", "application/json", false);
+  response.write("{\"test\":\"data\"}");
+}


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest#How_do_I_test_issues_which_only_show_up_when_tests_are_run_across_domains.3F
for info on how the test server was set up for testing that fetch was
used correctly.

Prior to this I was getting the following error when trying to fetch recipes with the built-in system add-on:

```
*************************
A coding exception was thrown and uncaught in a Task.

Full message: ReferenceError: fetch is not defined
Full stack: apiCall@resource://shield-recipe-client/lib/NormandyApi.jsm:36:5
get@resource://shield-recipe-client/lib/NormandyApi.jsm:43:12
this.NormandyApi.fetchRecipes<@resource://shield-recipe-client/lib/NormandyApi.jsm:51:34
TaskImpl_run@resource://gre/modules/Task.jsm:319:42
TaskImpl@resource://gre/modules/Task.jsm:277:3
asyncFunction@resource://gre/modules/Task.jsm:252:14
this.RecipeRunner.start<@resource://shield-recipe-client/lib/RecipeRunner.jsm:63:23
TaskImpl_run@resource://gre/modules/Task.jsm:319:42
TaskImpl@resource://gre/modules/Task.jsm:277:3
asyncFunction@resource://gre/modules/Task.jsm:252:14
setTimeout_timer@resource://gre/modules/Timer.jsm:30:5

*************************
```