### PR TITLE
Do not use an XRay-ed Promise during recipe execution.

### DIFF
--- a/lib/RecipeRunner.jsm
+++ b/lib/RecipeRunner.jsm
@@ -147,11 +147,9 @@ this.RecipeRunner = {
       const sandboxManager = new SandboxManager();
       const {sandbox} = sandboxManager;
       const prepScript = `
-        var pendingAction = null;
-
         function registerAction(name, Action) {
           let a = new Action(sandboxedDriver, sandboxedRecipe);
-          pendingAction = a.execute()
+          a.execute()
             .then(actionFinished)
             .catch(err => sandboxedDriver.log(err, 'error'));
         };

--- a/lib/RecipeRunner.jsm
+++ b/lib/RecipeRunner.jsm
@@ -128,35 +128,54 @@ this.RecipeRunner = {
    * @promise Resolves when the action has executed
    */
   executeRecipe: Task.async(function* (recipe, extraContext) {
-    const sandboxManager = new SandboxManager();
-    const {sandbox} = sandboxManager;
-
     const action = yield NormandyApi.fetchAction(recipe.action);
     const response = yield fetch(action.implementation_url);
 
     const actionScript = yield response.text();
-    const prepScript = `
-      var pendingAction = null;
+    yield this.executeAction(recipe, extraContext, actionScript);
+  }),
 
-      function registerAction(name, Action) {
-        let a = new Action(sandboxedDriver, sandboxedRecipe);
-        pendingAction = a.execute()
-          .catch(err => sandboxedDriver.log(err, 'error'));
+  /**
+   * Execute an action in a sandbox for a specific recipe.
+   * @param  {Object} recipe A recipe to execute
+   * @param  {Object} extraContext Extra data about the user, see NormandyDriver
+   * @param  {String} actionScript The JavaScript for the action to execute.
+   * @promise Resolves or rejects when the action has executed or failed.
+   */
+  executeAction: function(recipe, extraContext, actionScript) {
+    return new Promise((resolve, reject) => {
+      const sandboxManager = new SandboxManager();
+      const {sandbox} = sandboxManager;
+      const prepScript = `
+        var pendingAction = null;
+
+        function registerAction(name, Action) {
+          let a = new Action(sandboxedDriver, sandboxedRecipe);
+          pendingAction = a.execute()
+            .then(actionFinished)
+            .catch(err => sandboxedDriver.log(err, 'error'));
+        };
+
+        window.registerAction = registerAction;
+        window.setTimeout = sandboxedDriver.setTimeout;
+        window.clearTimeout = sandboxedDriver.clearTimeout;
+      `;
+
+      const driver = new NormandyDriver(sandboxManager, extraContext);
+      sandbox.sandboxedDriver = Cu.cloneInto(driver, sandbox, {cloneFunctions: true});
+      sandbox.sandboxedRecipe = Cu.cloneInto(recipe, sandbox);
+      sandbox.actionFinished = result => {
+        sandboxManager.removeHold("recipeExecution");
+        resolve(result);
+      };
+      sandbox.actionFailed = err => {
+        sandboxManager.removeHold("recipeExecution");
+        reject(err);
       };
 
-      window.registerAction = registerAction;
-      window.setTimeout = sandboxedDriver.setTimeout;
-      window.clearTimeout = sandboxedDriver.clearTimeout;
-    `;
-
-    const driver = new NormandyDriver(sandboxManager, extraContext);
-    sandbox.sandboxedDriver = Cu.cloneInto(driver, sandbox, {cloneFunctions: true});
-    sandbox.sandboxedRecipe = Cu.cloneInto(recipe, sandbox);
-
-    Cu.evalInSandbox(prepScript, sandbox);
-    Cu.evalInSandbox(actionScript, sandbox);
-
-    sandboxManager.addHold("recipeExecution");
-    sandbox.pendingAction.then(() => sandboxManager.removeHold("recipeExecution"));
-  }),
+      sandboxManager.addHold("recipeExecution");
+      Cu.evalInSandbox(prepScript, sandbox);
+      Cu.evalInSandbox(actionScript, sandbox);
+    });
+  },
 };

--- a/test/browser.ini
+++ b/test/browser.ini
@@ -6,3 +6,4 @@
 [browser_NormandyApi.js]
   support-files =
     test_server.sjs
+[browser_RecipeRunner.js]

--- a/test/browser_RecipeRunner.js
+++ b/test/browser_RecipeRunner.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const {utils: Cu} = Components;
+Cu.import("resource://shield-recipe-client/lib/RecipeRunner.jsm", this);
+
+add_task(function*() {
+  // Test that RecipeRunner can execute a basic recipe/action.
+  const recipe = {
+    foo: "bar",
+  };
+  const actionScript = `
+    class TestAction {
+      constructor(driver, recipe) {
+        this.recipe = recipe;
+      }
+
+      execute() {
+        return new Promise(resolve => {
+          resolve(this.recipe.foo);
+        });
+      }
+    }
+
+    registerAction('test-action', TestAction);
+  `;
+
+  const result = yield RecipeRunner.executeAction(recipe, {}, actionScript);
+  is(result, "bar", "Recipe was not executed.");
+});

--- a/test/browser_RecipeRunner.js
+++ b/test/browser_RecipeRunner.js
@@ -25,5 +25,5 @@ add_task(function*() {
   `;
 
   const result = yield RecipeRunner.executeAction(recipe, {}, actionScript);
-  is(result, "bar", "Recipe was not executed.");
+  is(result, "bar", "Recipe executed correctly");
 });


### PR DESCRIPTION
The RecipeRunner uses a promise from the sandbox to detect when
execution is done, but the promise methods aren't available since the
object is XRay-ed and its prototype is set to Object.

Instead, this patch uses two new functions passed to the sandbox that
map to resolving or rejecting a promise. The new executeAction function
returns a Promise defined outside the sandbox, but resolved or rejected
from within it when execution is finished.

The Promise also makes testing a bit easier as we can now inspect the
value that the sandbox resolves with.

With this patch I was able to get recipes to execute correctly finally, yay!